### PR TITLE
feat: add query option for readsql in sendemail job

### DIFF
--- a/src/ai/router/router.py
+++ b/src/ai/router/router.py
@@ -253,9 +253,14 @@ async def handle_turn(memory: Memory, user_utterance: str) -> Tuple[Memory, str]
                     memory.execute_query_enabled = execute_query  # Track if data was auto-written
                     memory.stage = Stage.SHOW_RESULTS
                     
-                    # Note: output_table_info is NOT set here for ReadSQL
-                    # SendEmail requires WriteData to be done first for ReadSQL flow
-                    # (CompareSQL sets output_table_info directly since it writes results as part of job)
+                    # Track output table info for send_email query generation
+                    # When execute_query=true, data is written to result_schema.table_name
+                    if execute_query:
+                        memory.output_table_info = {
+                            "schema": params.get("result_schema"),
+                            "table": params.get("table_name")
+                        }
+                        logger.info(f"📝 Set output_table_info from ReadSQL: {memory.output_table_info}")
                     
                     cols_str = ", ".join(memory.last_columns[:5])
                     if len(memory.last_columns) > 5:


### PR DESCRIPTION
## Changes

- Add `FETCH_SCHEMAS` action in router to dynamically retrieve schemas from ICC API for selected connections
- Refactor schema retrieval in job_agent to utilize cached schemas from memory before triggering API fetch
- Implement async schema fetching flow with proper authentication and error handling
- Track output table information (`schema`, `table_name`) in memory when `execute_query=true` for ReadSQL jobs
- Enable SendEmail query generation to access output table info from ReadSQL flow
- Add graceful fallback when schema fetching fails, prompting user without available schemas list
- Remove static db_config.json dependency for schema retrieval in favor of live ICC API calls

## Files Changed

- `src/ai/router/router.py` - Added FETCH_SCHEMAS handler and output_table_info tracking
- `src/ai/router/job_agent.py` - Refactored to use cached schemas and signal FETCH_SCHEMAS action