### PR TITLE
refactor: enhance handling of duplicate job names for all job templates

### DIFF
--- a/src/ai/router/stage_handlers/comparesql_handler.py
+++ b/src/ai/router/stage_handlers/comparesql_handler.py
@@ -640,10 +640,13 @@ class CompareSQLHandler(BaseStageHandler):
                 )
         
         except DuplicateJobNameError as e:
-            logger.warning(f"Duplicate job name: {e}")
+            logger.warning(f"Duplicate job name '{job_name}': {e}")
+            # Clear only the name - keep all other params for retry
+            memory.gathered_params["job_name"] = ""
+            memory.last_question = None  # Trigger fresh prompt for name
             return self._create_result(
                 memory,
-                e.user_message + "\n\nPlease provide a different name:",
+                f"A job named '{job_name}' already exists. Please provide a different name:",
                 is_error=True,
                 error_code=e.code
             )

--- a/src/ai/router/stage_handlers/readsql_handler.py
+++ b/src/ai/router/stage_handlers/readsql_handler.py
@@ -385,10 +385,13 @@ class ReadSQLHandler(BaseStageHandler):
                 )
 
         except DuplicateJobNameError as e:
-            logger.warning(f"Duplicate job name: {e}")
+            logger.warning(f"Duplicate job name '{job_name}': {e}")
+            # Clear only the name - keep all other params for retry
+            memory.gathered_params["name"] = ""
+            memory.last_question = None  # Trigger fresh prompt for name
             return self._create_result(
                 memory,
-                e.user_message + "\n\nWhat would you like to name this job instead?",
+                f"A job named '{job_name}' already exists. Please provide a different name:",
                 is_error=True,
                 error_code=e.code
             )

--- a/src/ai/router/stage_handlers/writedata_handler.py
+++ b/src/ai/router/stage_handlers/writedata_handler.py
@@ -278,10 +278,13 @@ class WriteDataHandler(BaseStageHandler):
             return self._create_result(memory, response)
 
         except DuplicateJobNameError as e:
-            logger.warning(f"Duplicate job name: {e}")
+            logger.warning(f"Duplicate job name '{job_name}': {e}")
+            # Clear only the name - keep all other params for retry
+            memory.gathered_params["name"] = ""
+            memory.last_question = None  # Trigger fresh prompt for name
             return self._create_result(
                 memory,
-                e.user_message + "\n\nWhat would you like to name this job instead?",
+                f"A job named '{job_name}' already exists. Please provide a different name:",
                 is_error=True,
                 error_code=e.code
             )

--- a/src/repositories/base_repository.py
+++ b/src/repositories/base_repository.py
@@ -335,12 +335,9 @@ class BaseRepository:
             logger.debug(f"POST request successful at {endpoint}")
             return response
             
-        except DuplicateJobNameError as e:
-            logger.warning(f"Duplicate job name error: {e.user_message}")
-            return APIResponse.error_response(
-                error=e.user_message,
-                status_code=self.CONFLICT_STATUS_CODE
-            )
+        except DuplicateJobNameError:
+            # Re-raise to let handlers deal with it and enable retry with new name
+            raise
             
         except AuthenticationError as e:
             logger.error(f"Authentication error: {e}")


### PR DESCRIPTION
## Fix: Duplicate Job Name Handling with Automatic Retry
 
### Summary
 
Implements comprehensive duplicate job name handling across all job types. When the ICC API returns a duplicate name error, the system now detects it, clears only the job name, keeps all other parameters, and prompts for a new name.
 
### Problem
 
Previously, duplicate name errors required users to re-enter ALL parameters from scratch.
 
### Solution
 
Reactive validation: detect duplicate at submission, clear only name, retry with new name.
 
### Changes
 
| File | Change |

`base_repository.py` | Re-raise `DuplicateJobNameError` instead of converting to response |

`icc_toolkit.py` | Re-raise in all 4 job methods + fallback detection |

`readsql_handler.py` | Clear name on duplicate, keep other params |

`writedata_handler.py` | Clear name on duplicate, keep other params |

`sendemail_handler.py` | Clear name + special name retry detection for confirm stage |

`comparesql_handler.py` | Clear job_name on duplicate, keep other params |
 
### User Experience
 
**Before:** Error → Start over, re-enter all params
 
**After:** System asks for new name → User provides it → Job created with all original params preserved

 